### PR TITLE
add stockproductID to dtypes

### DIFF
--- a/bin/pamidb_to_json.py
+++ b/bin/pamidb_to_json.py
@@ -7,7 +7,8 @@ dtypes = {
 	'digitizationProcess.captureSoftware.version': object,
 	'digitizationProcess.playbackDevice.serialNumber': object,
 	'digitizationProcess.timeBaseCorrector.serialNumber': object,
-	'digitizationProcess.phonoPreamp.serialNumber': object
+	'digitizationProcess.phonoPreamp.serialNumber': object,
+	'physicalDescription.properties.stockProductID': object
 }
 
 


### PR DESCRIPTION
is 'physicalDescription.properties.stockProductID' correct, or should it be 'physicalDescription.stockProductID'?
Thanks!