### PR TITLE
Subobjectness

### DIFF
--- a/ami_bag/ami_bag.py
+++ b/ami_bag/ami_bag.py
@@ -90,7 +90,13 @@ class ami_bag(update_bag.Repairable_Bag):
         try:
             self.check_simple_filenames()
         except ami_bagError as e:
-            LOGGER.error("Filenames out of spec: {0}".format(e.message))
+            LOGGER.warning("Filenames represent complex subobject: {0}".format(e.message))
+            warning = True
+        
+        try:
+            self.check_part_filenames()
+        except ami_bagError as e:
+            LOGGER.error("Filenames represent part file: {0}".format(e.message))
             error = True
 
         try:
@@ -235,6 +241,20 @@ class ami_bag(update_bag.Repairable_Bag):
 
         if complex_filenames:
             raise ami_bagError("Complex digitized objects represented by: {}".format(complex_filenames))
+
+        return True
+
+
+    def check_part_filenames(self):
+        part_filenames = []
+
+        for filepath in self.data_files:
+            filename = os.path.split(filepath)[1]
+            if ami_bag_constants.SUBOBJECT_PART_REGEX.search(filename):
+                part_filenames.append(filename)
+
+        if part_filenames:
+            raise ami_bagError("Part files represented by: {}".format(part_filenames))
 
         return True
 
@@ -567,7 +587,7 @@ class ami_bag(update_bag.Repairable_Bag):
 
             pm_path = os.path.join(self.path, "data/PreservationMasters")
             pm_filepaths = [x for x in self.media_filepaths if pm_path in x]
-            print(pm_filepaths)
+            
             excel.pres_sheet.convert_amiExcelToJSON(pm_path, filepaths = pm_filepaths)
 
 

--- a/ami_bag/ami_bag_constants.py
+++ b/ami_bag/ami_bag_constants.py
@@ -4,6 +4,7 @@ FILENAME_REGEX = re.compile(
     "([a-z]{3}_[a-z0-9]+_v\d{2}(([frspt]\d{2})+)?_(ao|pm|mz|em|sc|pf|assetfront|assetback|assetside|boxfront|boxback|boxside|reelfront|ephemera)([~\d\-]+)?\.[a-z0-9]+)|(\d{4}_\d{3}_[\da-zA-Z_]+\.(xlsx|old))",
     re.IGNORECASE)
 SUBOBJECT_REGEX = re.compile("_v\d{2}(f\d{2})?([rspt]\d{2})+")
+SUBOBJECT_PART_REGEX = re.compile("_v\d{2}([frst\d]+)?(p|pt)\d{2}")
 
 MD_DIR = "Metadata"
 PM_DIR = "PreservationMasters"

--- a/tests/test_ami_bag.py
+++ b/tests/test_ami_bag.py
@@ -159,6 +159,15 @@ class TestJSONVideoAMIBag(SelfCleaningTestCase):
 		# Invalid if bag has more complex subobjects than faces
 		# Method: Add complex subobject tags
 		for filename in glob.glob(self.tmpdir + "/**/*"):
+			os.rename(filename, filename.replace('_v01_', '_v01r01_'))
+		bagit.make_bag(self.tmpdir)
+		bag = ami_bag.ami_bag(path = self.tmpdir)
+		self.assertFalse(bag.validate_amibag())
+
+	def test_complex_subobject_with_parts(self):
+		# Invalid if bag has part files
+		# Method: Add part file tags
+		for filename in glob.glob(self.tmpdir + "/**/*"):
 			os.rename(filename, filename.replace('_v01_', '_v01r01p01_'))
 		bagit.make_bag(self.tmpdir)
 		bag = ami_bag.ami_bag(path = self.tmpdir)


### PR DESCRIPTION
Responding to requests from @bturkus and @genfhk to pass objects with regions, streams, takes.

New behavior is to issue a warning for those objects in order to help diagnose issue with excel->json bag conversion.

Objects with part files (p## or pt##) still receive any error during validation.