### PR TITLE
update ami_file

### DIFF
--- a/ami_files/ami_file.py
+++ b/ami_files/ami_file.py
@@ -59,8 +59,6 @@ class ami_file:
     self.date_filesys_created = datetime.fromtimestamp(os.path.getctime(self.filepath)).strftime('%Y-%m-%d')
     if md_track.encoded_date:
       self.date_created = parse_date(md_track.encoded_date)
-    elif md_track.recorded_date:
-      self.date_created = parse_date(md_track.recorded_date)
     elif md_track.file_last_modification_date:
       self.date_created = parse_date(md_track.file_last_modification_date)
     else:


### PR DESCRIPTION
remove date recorded test, as this was tripping up dv files (record date of 2004, for ex, not matching file last modified date we pull during metadata extraction). As this field is mostly there to track digitization date, this would seem an appropriate change.