### PR TITLE
Dvd validate

### DIFF
--- a/ami_files/ami_file.py
+++ b/ami_files/ami_file.py
@@ -64,10 +64,13 @@ class ami_file:
     else:
       self.date_created = self.date_filesys_created
 
-    self.duration_milli = md_track.duration
-    self.duration_human = parse_duration(self.duration_milli)
+    if md_track.duration:
+      self.duration_milli = md_track.duration
+      self.duration_human = parse_duration(self.duration_milli)
 
-    if '/' in md_track.audio_codecs:
+    if not md_track.audio_codecs:
+      pass
+    elif '/' in md_track.audio_codecs:
       self.audio_codec = '|'.join(set(x.strip() for x in md_track.audio_codecs.split('/')))
     else:
       self.audio_codec = md_track.audio_codecs

--- a/ami_md/ami_json.py
+++ b/ami_md/ami_json.py
@@ -187,6 +187,9 @@ class ami_json:
 
     if self.media_format_type == "audio":
       expected_fields = set(ami_md_constants.JSON_AUDIOFIELDS)
+    elif (self.dict["asset"]["fileRole"] == 'pm'
+          and self.dict["source"]["object"]["type"] == 'video optical disc'):
+      expected_fields = set(ami_md_constants.JSON_VIDEOOPTICALPMFIELDS)
     elif self.media_format_type == "video":
       expected_fields = set(ami_md_constants.JSON_VIDEOFIELDS)
     elif (self.media_format_type == "film"
@@ -226,6 +229,9 @@ class ami_json:
 
     if self.media_format_type == "audio":
       field_mapping = ami_md_constants.JSON_TO_AUDIO_FILE_MAPPING
+    elif (self.dict["asset"]["fileRole"] == 'pm'
+          and self.dict["source"]["object"]["type"] == 'video optical disc'):
+      field_mapping = ami_md_constants.JSON_TO_VIDEOOPTICALPM_FILE_MAPPING
     elif self.media_format_type == "video":
       field_mapping = ami_md_constants.JSON_TO_VIDEO_FILE_MAPPING
     elif (self.media_format_type == "film"

--- a/ami_md/ami_md_constants.py
+++ b/ami_md/ami_md_constants.py
@@ -31,6 +31,8 @@ JSON_AUDIOFIELDS = ["filename", "extension", "fileFormat",
 JSON_VIDEOFIELDS = ["filename", "extension", "fileFormat",
   "fileSize", "dateCreated", "durationHuman", "durationMilli",
   "audioCodec", "videoCodec"]
+JSON_VIDEOOPTICALPMFIELDS = ["filename", "extension", "fileFormat",
+  "fileSize", "dateCreated"]
 
 JSON_TO_AUDIO_FILE_MAPPING = {
   'filename': 'base_filename',
@@ -45,6 +47,14 @@ JSON_TO_AUDIO_FILE_MAPPING = {
 
 JSON_TO_VIDEO_FILE_MAPPING = JSON_TO_AUDIO_FILE_MAPPING.copy()
 JSON_TO_VIDEO_FILE_MAPPING['videoCodec'] = 'video_codec'
+
+JSON_TO_VIDEOOPTICALPM_FILE_MAPPING = {
+  'filename': 'base_filename',
+  'extension': 'extension',
+  'fileFormat': 'format',
+  'fileSize.measure': 'size',
+  'dateCreated': 'date_created'
+}
 
 
 HEADER_CONVERSION = {


### PR DESCRIPTION
DVD PM's are ISOs. These don't have duration, video codecs, or audio codecs that are easily reported from mediainfo. This PR pares back ami_file and ami_json expectations around those fields.